### PR TITLE
Replace httpx with httpx2

### DIFF
--- a/GCP.md
+++ b/GCP.md
@@ -219,7 +219,7 @@ No direct Cloud Logging API usage (stdout ingestion). Ensure log-based metrics /
 
 ---
 ### 12. Security Notes & Hardening Checklist
-- Remove unused deps (`python-jose`, `httpx`) if not planned.
+- Remove unused direct deps (`python-jose`, `httpx2`) if not planned.
 - Enforce HTTPS (Cloud Run provides TLS terminator; HSTS enabled by middleware when configured).
 - Set `DEBUG=false` in production.
 - Restrict CORS explicitly (`CORS_ORIGINS`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ dependencies = [
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",
     "uvicorn[standard]>=0.44.0",
-    "httpx>=0.28.1",
     "fastapi-problem>=0.12.1",
     "cbor2>=5.7.1",
+    "httpx2>=2.4.0",
 ]
 
 [dependency-groups]
@@ -20,7 +20,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
-    "pytest-httpx>=0.36.2",
+    "pytest-httpx2>=1.0.0",
     "pytest-mock>=3.15.1",
     "ruff>=0.15.10",
     "ty>=0.0.24",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,8 +1,8 @@
 ---
-description: Testing guidelines for this FastAPI/Python repository. Covers pytest conventions, fixtures, mocks, and test structure (Python 3.14, pytest, pytest-asyncio, httpx, pytest-httpx).
+description: Testing guidelines for this FastAPI/Python repository. Covers pytest conventions, fixtures, mocks, and test structure (Python 3.14, pytest, pytest-asyncio, httpx2, pytest-httpx2).
 ---
 
-Use these rules for tests under `tests/**` (Python 3.14, FastAPI, pytest, pytest-asyncio). The project uses `httpx` for HTTP clients and `pytest-httpx` for mocking outbound HTTP in tests.
+Use these rules for tests under `tests/**` (Python 3.14, FastAPI, pytest, pytest-asyncio). The project uses `httpx2` for HTTP clients and `pytest-httpx2` for mocking outbound HTTP in tests.
 
 > **Ruff Linter Coverage**: Test patterns are enforced via Ruff (see `pyproject.toml`):
 > - **PT**: Pytest style (fixture parentheses, assertion patterns, parametrize syntax, marks)
@@ -132,8 +132,8 @@ Test File Mapping:
 
 Conventions
 - No real network, files, or Firebase/Google Cloud in unit/integration tests; mock `firebase_admin` and any external I/O.
-- Prefer FastAPI patterns from the docs: use `TestClient` for sync-style API tests; use `httpx.AsyncClient` for true async cases (no `@pytest.mark.asyncio` needed with `asyncio_mode = "auto"`).
-- HTTP client and mocking: use `httpx` in code; stub outbound HTTP with `pytest-httpx` via the `httpx_mock` fixture. Do not hit the real network.
+- Prefer FastAPI patterns from the docs: use `TestClient` for sync-style API tests; use `httpx2.AsyncClient` for true async cases (no `@pytest.mark.asyncio` needed with `asyncio_mode = "auto"`).
+- HTTP client and mocking: use `httpx2` in code; stub outbound HTTP with `pytest-httpx2` via the `httpx2_mock` fixture. Do not hit the real network.
 - **Prefer `pytest-mock` (`mocker` fixture) over `monkeypatch`** when mocking. Use `mocker.patch()` for patching with `MagicMock`/`AsyncMock` features (call assertions, return values, side effects). Reserve `monkeypatch` for simpler cases: environment variables (`setenv`), `sys.path` manipulation, or `chdir`. Choose the right tool for the task.
 - Override dependencies via `app.dependency_overrides` (e.g., auth/user, database/session). Reset overrides after each test to avoid leakage.
 - **URL formatting**: Always use paths without trailing slashes (e.g., `"/v1/profile"` not `"/v1/profile/"`). The app has `redirect_slashes=False`, so requests must match the exact path. Business endpoints are under `/v1/` prefix (e.g., `/v1/profile`, `/v1/hello`, `/v1/items`).
@@ -309,7 +309,7 @@ import contextlib
 import os
 from collections.abc import Generator
 
-import httpx
+import httpx2
 import pytest
 from fastapi.testclient import TestClient
 
@@ -325,9 +325,9 @@ def _emulator_running(host: str) -> bool:
     Check if an emulator is running at the given host.
     """
     try:
-        httpx.get(f"http://{host}/", timeout=1.0)
+        httpx2.get(f"http://{host}/", timeout=1.0)
         return True
-    except httpx.RequestError:
+    except httpx2.RequestError:
         return False
 
 
@@ -349,8 +349,8 @@ def clear_emulator_data() -> Generator[None]:
     Clear Firestore emulator data after each test.
     """
     yield
-    with contextlib.suppress(httpx.RequestError):
-        httpx.delete(
+    with contextlib.suppress(httpx2.RequestError):
+        httpx2.delete(
             f"http://{FIRESTORE_HOST}/emulator/v1/projects/{PROJECT_ID}/databases/(default)/documents",
             timeout=5.0,
         )
@@ -562,7 +562,7 @@ def make_profile_payload_dict(
 
 Assertion helpers (`tests/helpers/assertions.py`):
 ```python
-from httpx import Response
+from httpx2 import Response
 
 
 def assert_error_response(response: Response, expected_status: int) -> dict:
@@ -669,7 +669,7 @@ Organize mock objects and stub factories in `tests/mocks/`. Use Protocol types f
 |--------|---------|
 | `firebase.py` | Firebase auth mocks, token verification patches |
 | `firestore.py` | Fake Firestore client, collections, documents, transactions for unit tests |
-| `http.py` | HTTP client mock helpers (pytest-httpx wrappers) |
+| `http.py` | HTTP client mock helpers (pytest-httpx2 wrappers) |
 | `services.py` | Service layer stubs and mock factories |
 
 Mock patterns:
@@ -711,20 +711,17 @@ def create_mock_profile_service_not_found() -> AsyncMock:
     return mock
 ```
 
-Protocol pattern for type-safe mocks:
+HTTP mock helper pattern:
 ```python
 # tests/mocks/http.py
-from typing import Protocol
+from respx import Router
+from respx.models import Route
 
-class HTTPXMock(Protocol):
+def add_ok_response(httpx2_mock: Router, url: str, json: dict | None = None) -> Route:
     """
-    Minimal protocol for pytest-httpx fixture type hints.
+    Add a successful GET response to the mock.
     """
-
-    def add_response(self, *, method: str, url: str, json: dict | None = None, status_code: int = 200) -> None: ...
-
-def add_ok_response(httpx_mock: HTTPXMock, url: str, json: dict | None = None) -> None:
-    httpx_mock.add_response(method="GET", url=url, json=json or {"ok": True}, status_code=200)
+    return httpx2_mock.get(url).respond(status_code=200, json=json or {"ok": True})
 
 # Usage in tests:
 mock_service = AsyncMock(spec=ProfileService)
@@ -1103,7 +1100,7 @@ Run commands (repo root)
 5) `just test-all` (all tests including E2E)
 6) `just cov` (coverage report to `htmlcov/`)
 7) Optional: `uv run -m pytest` if not using `just`
-8) The `pytest-httpx` plugin is auto-discovered by pytest; import is not required for activation.
+8) The `pytest-httpx2` plugin is auto-discovered by pytest; import is not required for activation.
 9) pytest-asyncio is configured in `pyproject.toml` with:
    - `asyncio_mode = "auto"` - async tests/fixtures auto-detected
    - `asyncio_default_fixture_loop_scope = "function"` - async fixtures run in function-scoped loop
@@ -1127,17 +1124,17 @@ def test_health_ok() -> None:
 		assert body["message"] == "healthy"
 ```
 
-2) Async test (true async using httpx AsyncClient)
+2) Async test (true async using httpx2 AsyncClient)
 - Useful for `async` flows or when you need `await` behavior. Use `ASGITransport` for ASGI apps.
 - No `@pytest.mark.asyncio` needed with `asyncio_mode = "auto"`.
 
 ```python
-import httpx
+import httpx2
 from app.main import app
 
 async def test_health_async() -> None:
-	transport = httpx.ASGITransport(app=app)
-	async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+	transport = httpx2.ASGITransport(app=app)
+	async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as ac:
 		r = await ac.get("/health")
 		assert r.status_code == 200
 		assert r.json() == {"status": "healthy"}
@@ -1229,85 +1226,51 @@ def test_security_headers() -> None:
 		assert r.headers.get("referrer-policy") == "same-origin"
 ```
 
-7) Mocking outbound HTTP with pytest-httpx
-- Use the `httpx_mock` fixture (provided by pytest-httpx) to intercept external requests made with `httpx`. Provide deterministic responses and avoid network.
-- The fixture is auto-injected; no import needed. Type hint with `pytest_httpx.HTTPXMock` if desired.
+7) Mocking outbound HTTP with pytest-httpx2
+- Use the `httpx2_mock` fixture (provided by pytest-httpx2) to intercept external requests made with `httpx2`. Provide deterministic responses and avoid network.
+- The fixture is auto-injected; no import needed. It yields a `respx.Router`.
 
 ```python
-import httpx
-from pytest_httpx import HTTPXMock
+import httpx2
+from respx import Router
 
-def test_outbound_call(httpx_mock: HTTPXMock) -> None:
+def test_outbound_call(httpx2_mock: Router) -> None:
 	# Arrange a mocked HTTP response
-	httpx_mock.add_response(
-		method="GET",
-		url="https://example.com/api/status",
-		json={"ok": True},
-		status_code=200,
-	)
+	httpx2_mock.get("https://example.com/api/status").respond(status_code=200, json={"ok": True})
 
-	# Exercise code under test that internally calls httpx.get(...)
-	resp = httpx.get("https://example.com/api/status")
+	# Exercise code under test that internally calls httpx2.get(...)
+	resp = httpx2.get("https://example.com/api/status")
 
 	# Assert
 	assert resp.status_code == 200
 	assert resp.json() == {"ok": True}
 ```
 
-pytest-httpx advanced patterns:
+pytest-httpx2 request assertions:
 ```python
-# Dynamic callback response
-async def test_dynamic_response(httpx_mock: HTTPXMock) -> None:
-    async def simulate_latency(request: httpx.Request) -> httpx.Response:
-        await asyncio.sleep(0.1)
-        return httpx.Response(status_code=200, json={"url": str(request.url)})
+def test_request_assertions(httpx2_mock: Router) -> None:
+    route = httpx2_mock.get("https://api.example.com/data").respond(status_code=200, json={})
 
-    httpx_mock.add_callback(simulate_latency)
-    async with httpx.AsyncClient() as client:
-        response = await client.get("https://api.example.com/data")
-        assert response.json()["url"] == "https://api.example.com/data"
-```
-
-Asserting all mocked responses were used:
-```python
-# By default, pytest-httpx asserts all registered responses are used
-# Disable per-test with the httpx_mock marker:
-@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
-def test_optional_call(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(url="https://optional.example.com")
-    # Test passes even if the mocked URL is never called
-```
-
-pytest-httpx assertion methods:
-```python
-def test_request_assertions(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(url="https://api.example.com/data")
-    
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
         client.get("https://api.example.com/data")
-    
-    # Assert request was made
-    httpx_mock.assert_called()
-    httpx_mock.assert_called_once()
-    
-    # Get request for detailed inspection
-    request = httpx_mock.get_request()
-    assert request.url == "https://api.example.com/data"
-    assert request.method == "GET"
+
+    assert route.called
+    assert len(httpx2_mock.calls) == 1
+    assert str(httpx2_mock.calls[0].request.url) == "https://api.example.com/data"
 ```
 
-8) Simulating HTTP exceptions with pytest-httpx
-- Use `add_exception` to test error handling for timeouts, connection errors, etc.
+8) Simulating HTTP exceptions with pytest-httpx2
+- Use `mock(side_effect=...)` to test error handling for timeouts, connection errors, etc.
 
 ```python
-import httpx
+import httpx2
 import pytest
-from pytest_httpx import HTTPXMock
+from respx import Router
 
-def test_timeout_handling(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_exception(httpx.ReadTimeout("Connection timed out"))
-    with pytest.raises(httpx.ReadTimeout):
-        with httpx.Client() as client:
+def test_timeout_handling(httpx2_mock: Router) -> None:
+    httpx2_mock.get("https://api.example.com/data").mock(side_effect=httpx2.ReadTimeout("Connection timed out"))
+    with pytest.raises(httpx2.ReadTimeout):
+        with httpx2.Client() as client:
             client.get("https://api.example.com/data")
 ```
 
@@ -1493,11 +1456,11 @@ finally:
 
 Common pitfalls (and fixes)
 - Not clearing `app.dependency_overrides`: tests influence each other. Use `try/finally` or context manager.
-- Mixing sync TestClient inside async tests: use `httpx.AsyncClient` or keep tests sync.
+- Mixing sync TestClient inside async tests: use `httpx2.AsyncClient` or keep tests sync.
 - Creating `TestClient(app)` without context manager: lifespan may not run; use fixture with `with`.
 - Real Firebase/GCP calls in tests: must be mocked.
 - Weak assertions: assert status, body shape, and headers.
-- Real outbound HTTP not mocked: use `pytest-httpx`.
+- Real outbound HTTP not mocked: use `pytest-httpx2`.
 - Using `@pytest.mark.asyncio` when not needed: with `asyncio_mode="auto"`, remove the decorator.
 - Forgetting to clear cached settings: call `get_settings.cache_clear()` after `monkeypatch.setenv()`.
 - Applying marks to fixtures: deprecated in pytest 8+; use fixture dependencies instead.
@@ -1523,11 +1486,11 @@ def test_something(client: TestClient) -> None: ...
 Avoid: Real network calls
 ```python
 # BAD
-response = httpx.get("https://api.external.com/data")
+response = httpx2.get("https://api.external.com/data")
 
 # GOOD
-def test_call(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(url="https://api.external.com/data", json={})
+def test_call(httpx2_mock: Router) -> None:
+    httpx2_mock.get("https://api.external.com/data").respond(status_code=200, json={})
 ```
 
 Avoid: Hardcoded secrets

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,7 +12,7 @@ import contextlib
 import os
 from collections.abc import Generator
 
-import httpx
+import httpx2
 import pytest
 from fastapi.testclient import TestClient
 
@@ -28,9 +28,9 @@ def _emulator_running(host: str) -> bool:
     Check if an emulator is running at the given host.
     """
     try:
-        httpx.get(f"http://{host}/", timeout=1.0)
+        httpx2.get(f"http://{host}/", timeout=1.0)
         return True
-    except httpx.RequestError:
+    except httpx2.RequestError:
         return False
 
 
@@ -56,8 +56,8 @@ def clear_emulator_data() -> Generator[None]:
     Ensures test isolation by removing all documents.
     """
     yield
-    with contextlib.suppress(httpx.RequestError):
-        httpx.delete(
+    with contextlib.suppress(httpx2.RequestError):
+        httpx2.delete(
             f"http://{FIRESTORE_HOST}/emulator/v1/projects/{PROJECT_ID}/databases/(default)/documents",
             timeout=5.0,
         )

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -2,7 +2,7 @@
 Assertion helpers for tests.
 """
 
-from httpx import Response
+from httpx2 import Response
 
 
 def assert_error_response(response: Response, expected_status: int) -> dict:

--- a/tests/mocks/http.py
+++ b/tests/mocks/http.py
@@ -1,74 +1,44 @@
 """
-HTTP client mocking helpers using pytest-httpx.
+HTTP client mocking helpers using pytest-httpx2.
 """
 
-from typing import Protocol
-
-
-class HTTPXMock(Protocol):
-    """
-    Minimal protocol for pytest-httpx fixture type hints.
-    """
-
-    def add_response(
-        self,
-        *,
-        method: str,
-        url: str,
-        json: dict | None = None,
-        status_code: int = 200,
-    ) -> None: ...
-
-    def add_exception(self, exception: Exception) -> None: ...
+from respx import Router
+from respx.models import Route
 
 
 def add_ok_response(
-    httpx_mock: HTTPXMock,
+    httpx2_mock: Router,
     url: str,
     json: dict | None = None,
     status_code: int = 200,
-) -> None:
+) -> Route:
     """
     Add a successful GET response to the mock.
     """
-    httpx_mock.add_response(
-        method="GET",
-        url=url,
-        json=json or {"ok": True},
-        status_code=status_code,
-    )
+    return httpx2_mock.get(url).respond(status_code=status_code, json=json or {"ok": True})
 
 
 def add_post_response(
-    httpx_mock: HTTPXMock,
+    httpx2_mock: Router,
     url: str,
     json: dict | None = None,
     status_code: int = 200,
-) -> None:
+) -> Route:
     """
     Add a successful POST response to the mock.
     """
-    httpx_mock.add_response(
-        method="POST",
-        url=url,
-        json=json or {"ok": True},
-        status_code=status_code,
-    )
+    return httpx2_mock.post(url).respond(status_code=status_code, json=json or {"ok": True})
 
 
 def add_error_response(
-    httpx_mock: HTTPXMock,
+    httpx2_mock: Router,
     url: str,
     status_code: int = 500,
     method: str = "GET",
     json: dict | None = None,
-) -> None:
+) -> Route:
     """
     Add an error response to the mock.
     """
-    httpx_mock.add_response(
-        method=method,
-        url=url,
-        json=json or {"error": "Internal Server Error"},
-        status_code=status_code,
-    )
+    route = httpx2_mock.request(method, url)
+    return route.respond(status_code=status_code, json=json or {"error": "Internal Server Error"})

--- a/tests/unit/core/test_cbor.py
+++ b/tests/unit/core/test_cbor.py
@@ -472,7 +472,7 @@ class TestCBORRoute:
 
         Tests the branch where the for loop exits without finding b"accept" key.
         """
-        import httpx
+        import httpx2
         from fastapi import APIRouter, FastAPI
         from fastapi.testclient import TestClient
 
@@ -489,7 +489,7 @@ class TestCBORRoute:
 
         with TestClient(app) as client:
             # Send request with explicit headers that don't include Accept
-            req = httpx.Request(
+            req = httpx2.Request(
                 "GET",
                 "http://testserver/test",
                 headers=[("Host", "testserver"), ("User-Agent", "test")],

--- a/tests/unit/mocks/__init__.py
+++ b/tests/unit/mocks/__init__.py
@@ -1,0 +1,3 @@
+"""
+Unit tests for reusable test mocks.
+"""

--- a/tests/unit/mocks/test_http.py
+++ b/tests/unit/mocks/test_http.py
@@ -1,0 +1,71 @@
+"""
+Tests for httpx2 mock helpers.
+"""
+
+import httpx2
+import pytest
+from respx import Router
+
+from tests.mocks.http import add_error_response, add_ok_response, add_post_response
+
+
+class TestHTTPX2MockHelpers:
+    """
+    Tests for pytest-httpx2 helper functions.
+    """
+
+    def test_add_ok_response_mocks_get_request(self, httpx2_mock: Router) -> None:
+        """
+        Verify add_ok_response registers a GET response on the httpx2 mock.
+        """
+        route = add_ok_response(httpx2_mock, "https://api.example.test/status")
+
+        response = httpx2.get("https://api.example.test/status")
+
+        assert route.called
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+    def test_add_post_response_mocks_post_request(self, httpx2_mock: Router) -> None:
+        """
+        Verify add_post_response registers a POST response on the httpx2 mock.
+        """
+        route = add_post_response(
+            httpx2_mock,
+            "https://api.example.test/items",
+            json={"id": "item-1"},
+            status_code=201,
+        )
+
+        response = httpx2.post("https://api.example.test/items", json={"name": "Test"})
+
+        assert route.called
+        assert response.status_code == 201
+        assert response.json() == {"id": "item-1"}
+
+    def test_add_error_response_mocks_requested_method(self, httpx2_mock: Router) -> None:
+        """
+        Verify add_error_response registers the requested HTTP method.
+        """
+        route = add_error_response(
+            httpx2_mock,
+            "https://api.example.test/items/item-1",
+            method="PATCH",
+            status_code=503,
+            json={"error": "Unavailable"},
+        )
+
+        response = httpx2.patch("https://api.example.test/items/item-1", json={"name": "Updated"})
+
+        assert route.called
+        assert response.status_code == 503
+        assert response.json() == {"error": "Unavailable"}
+
+    def test_httpx2_mock_can_raise_httpx2_exception(self, httpx2_mock: Router) -> None:
+        """
+        Verify pytest-httpx2 supports httpx2 exception side effects.
+        """
+        httpx2_mock.get("https://api.example.test/timeout").mock(side_effect=httpx2.ReadTimeout("Timed out"))
+
+        with pytest.raises(httpx2.ReadTimeout):
+            httpx2.get("https://api.example.test/timeout")

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-problem" },
     { name = "firebase-admin" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "uvicorn", extra = ["standard"] },
@@ -382,7 +382,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
-    { name = "pytest-httpx" },
+    { name = "pytest-httpx2" },
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "ty" },
@@ -394,7 +394,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "fastapi-problem", specifier = ">=0.12.1" },
     { name = "firebase-admin", specifier = ">=7.4.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", specifier = ">=2.4.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
@@ -405,7 +405,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "pytest-httpx", specifier = ">=0.36.2" },
+    { name = "pytest-httpx2", specifier = ">=1.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.15.10" },
     { name = "ty", specifier = ">=0.0.24" },
@@ -680,6 +680,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/9b/2b1d1833a58236d1f6ee755e027a3917da0db59cc9708554cefc440ee8b6/httpcore2-2.4.0.tar.gz", hash = "sha256:3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422", size = 64618, upload-time = "2026-06-11T06:35:53.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/72/4fdf2306143a92a471fad9f3655aa542d43aa9188a7c9534e82c9aecf837/httpcore2-2.4.0-py3-none-any.whl", hash = "sha256:5218779da5d6e3c2013ac706121abfb3815d450e0613495c0de50264dce58242", size = 80151, upload-time = "2026-06-11T06:35:50.89Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -719,6 +732,21 @@ wheels = [
 [package.optional-dependencies]
 http2 = [
     { name = "h2" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/60/b43ced4ccf26e95b396dbf67051d3e5042b645917d4da0469dd82a3bdd4f/httpx2-2.4.0.tar.gz", hash = "sha256:32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef", size = 81691, upload-time = "2026-06-11T06:35:54.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/45/82bc57c3d9c3314f663b67cc057f1c017a6450685dde513f4f8db5cf431f/httpx2-2.4.0-py3-none-any.whl", hash = "sha256:425acd99297829599decf6701386dd84db3542597d36d3e2e4def930ecd57fd9", size = 74941, upload-time = "2026-06-11T06:35:52.235Z" },
 ]
 
 [[package]]
@@ -1115,16 +1143,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-httpx"
-version = "0.36.2"
+name = "pytest-httpx2"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "pytest" },
+    { name = "respx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/d1/70e7edb50679ddd34ba5e13ac1d6e1223bc4e24d0a5fc30587f8fbe884c4/pytest_httpx2-1.0.0.tar.gz", hash = "sha256:d897a14c1341d3f3014e9432c16fed366598aba06a2ba9c08460a51799cb7128", size = 2882, upload-time = "2026-05-20T08:26:41.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e1/5e38e8de42fba9667846a43113469c7481d01db4b6511e42645385bace8f/pytest_httpx2-1.0.0-py3-none-any.whl", hash = "sha256:467dc7f6946854ffc20e1678703266b093037d8f3fb9f1fb523a2c432c64cff0", size = 4504, upload-time = "2026-05-20T08:26:40.219Z" },
 ]
 
 [[package]]
@@ -1196,6 +1223,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]
@@ -1344,6 +1383,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/e0/fa662f593314824e5a62b57e929e60b42050b53646c2a21bf93f9894e643/starlette_problem-0.13.5.tar.gz", hash = "sha256:f7839f1692971b0de77ee04c9df1c02afff841e8f47abea7f2ef54359ef2408e", size = 83065, upload-time = "2026-02-10T10:07:26.28Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/cc/e36cf52424ea3142e7b38de6ce3fe416f63173d2e18325cb1e682dda21f6/starlette_problem-0.13.5-py3-none-any.whl", hash = "sha256:3fa1f19141ac675dcbcefd1871bd52beeccf7c3375ce162931f6a82fd8707b70", size = 11670, upload-time = "2026-02-10T10:07:25.006Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Close https://github.com/janisto/fastapi-playground/issues/90

Migrates the project’s direct HTTP client dependencies from httpx / pytest-httpx to httpx2 / pytest-httpx2.

Changes include:

- Replaced direct dependencies in pyproject.toml and regenerated uv.lock
- Updated test imports and helper typing to use httpx2
- Reworked HTTP mock helpers to use pytest-httpx2’s httpx2_mock / respx.Router conventions
- Added unit tests covering the new pytest-httpx2 helper behavior
- Updated test guidance docs to remove old pytest-httpx patterns