### PR TITLE
Handle invalid cursors without server errors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.middleware import (
     BodySizeLimitMiddleware,
     SecurityHeadersMiddleware,
 )
+from app.pagination import InvalidCursorError
 
 
 @asynccontextmanager
@@ -69,6 +70,9 @@ populate_schema_cache(openapi_schema)
 
 # Register RFC 9457 Problem Details exception handler
 add_exception_handler(fastapi_app, exception_handler)
+# This expected non-HTTP exception needs a specific registration so Starlette
+# handles it inside ExceptionMiddleware instead of re-raising it as a server error.
+fastapi_app.add_exception_handler(InvalidCursorError, exception_handler)
 
 settings = get_settings()
 application: ASGIApp = BodySizeLimitMiddleware(fastapi_app)

--- a/tests/integration/api/test_items.py
+++ b/tests/integration/api/test_items.py
@@ -4,6 +4,7 @@ Integration tests for items endpoint.
 
 import cbor2
 from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
 
 from app.pagination import MAX_CURSOR_LENGTH
 
@@ -359,6 +360,23 @@ class TestItemsInvalidCursor:
             "/v1/items",
             params={"cursor": "x" * (MAX_CURSOR_LENGTH + 1)},
         )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "cursor exceeds maximum length"
+
+    def test_oversized_cursor_does_not_escape_application(self, mocker: MockerFixture) -> None:
+        """Verify a handled cursor error does not propagate as a server exception."""
+        mocker.patch("app.main.initialize_firebase")
+        mocker.patch("app.main.configure_logging")
+        mocker.patch("app.main.close_async_firestore_client")
+
+        from app.main import app
+
+        with TestClient(app, raise_server_exceptions=True) as strict_client:
+            response = strict_client.get(
+                "/v1/items",
+                params={"cursor": "x" * (MAX_CURSOR_LENGTH + 1)},
+            )
 
         assert response.status_code == 400
         assert response.json()["detail"] == "cursor exceeds maximum length"


### PR DESCRIPTION
## Summary

- register `InvalidCursorError` specifically with FastAPI's exception handling
- keep pagination exceptions transport-neutral
- add a strict integration regression using `raise_server_exceptions=True`

## Why

Production verification showed that an oversized cursor returned the intended RFC 9457 400 response but then escaped through Starlette's generic server-error handler. Uvicorn consequently emitted an `Exception in ASGI application` ERROR for expected malformed client input.

The generic `Exception` handler runs in Starlette's `ServerErrorMiddleware`, which always re-raises after producing a response. Registering the expected exception class specifically routes it through the inner `ExceptionMiddleware`, where it is handled without propagating as a server failure.

## Impact

The public HTTP contract is unchanged: invalid cursors still return 400 Problem Details in the negotiated representation. The change prevents false application ERROR logs and alert noise.

## Validation

- `just test-integration` — 187 passed
- `just test` — 642 passed, 99.77% coverage
- `just lint`
- `just typing`