### PR TITLE
Add relevant badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # FastAPI Playground
 
+[![CI](https://img.shields.io/github/actions/workflow/status/janisto/fastapi-playground/app-ci.yml?branch=main&label=CI)](https://github.com/janisto/fastapi-playground/actions/workflows/app-ci.yml)
+[![Lint](https://img.shields.io/github/actions/workflow/status/janisto/fastapi-playground/app-lint.yml?branch=main&label=lint)](https://github.com/janisto/fastapi-playground/actions/workflows/app-lint.yml)
+[![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/github/license/janisto/fastapi-playground)](LICENSE)
+
 A FastAPI application demonstrating Firebase Authentication, Firestore CRUD operations, and modern Python development workflow using `uv` (dependency & virtualenv manager) and `just` (task runner).
 
 <img src="assets/python.svg" alt="Python logo" width="400">


### PR DESCRIPTION
## Summary

- add Shields.io badges for the main CI and lint workflows
- show the supported Python version and MIT license at a glance

## Why

This makes the repository's maintained compatibility and quality signals visible from the top of the README, with each badge linked to its source.

## Validation

- `git diff --check`
- verified all four Shields.io endpoints return SVG badges with the expected live values

Tests were not run because this is a documentation-only change.